### PR TITLE
Switch app entry point to AppRootView

### DIFF
--- a/MEAL AI/MealAIApp.swift
+++ b/MEAL AI/MealAIApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct MealAIApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            AppRootView()
         }
     }
 }


### PR DESCRIPTION
## Summary
- launch the app using `AppRootView` instead of `ContentView` so the tab bar shows new features

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project 'MEAL AI.xcodeproj' -scheme 'MEAL AI' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fbdd86e88329ade0a6ff5559493d