### PR TITLE
Replace camera search with Food Search

### DIFF
--- a/MEAL AI/ContentView.swift
+++ b/MEAL AI/ContentView.swift
@@ -122,7 +122,7 @@ struct ContentView: View {
 
     // Kuva & picker
     @State private var selectedImage: UIImage?
-    @State private var showCamera = false
+    @State private var showFoodSearch = false
     @State private var showLibrary = false
 
     // Prosessin tila
@@ -258,8 +258,8 @@ struct ContentView: View {
                     .buttonStyle(PressableButtonStyle())
                 }
             }
-            .fullScreenCover(isPresented: $showCamera) {
-                ImagePicker(sourceType: .camera) { image in
+            .fullScreenCover(isPresented: $showFoodSearch) {
+                FoodSearchView { image in
                     selectedImage = image
                     clearResultsOnly()
                 }
@@ -431,11 +431,11 @@ struct ContentView: View {
         HStack(spacing: 12) {
             Button {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                openCamera()
+                startFoodSearch()
             } label: {
                 VStack {
-                    Image(systemName: "camera")
-                    Text(loc("Ota kuva", en: "Camera"))
+                    Image(systemName: "fork.knife")
+                    Text(loc("Ruokahaku", en: "Food Search"))
                 }
             }
             .buttonStyle(PressableButtonStyle())
@@ -477,19 +477,19 @@ struct ContentView: View {
         .background(Color(UIColor.systemGray6))
     }
 
-    // MARK: - Kamera
-    private func openCamera() {
+    // MARK: - Food Search
+    private func startFoodSearch() {
         guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
             showLibrary = true
             return
         }
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .authorized:
-            DispatchQueue.main.async { self.showCamera = true }
+            DispatchQueue.main.async { self.showFoodSearch = true }
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .video) { granted in
                 DispatchQueue.main.async {
-                    if granted { self.showCamera = true }
+                    if granted { self.showFoodSearch = true }
                     else { self.showLibrary = true }
                 }
             }

--- a/MEAL AI/FoodSearchView.swift
+++ b/MEAL AI/FoodSearchView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import UIKit
+
+/// Replacement for the old camera-based search.
+/// Presents the camera and returns the captured image for food searching.
+struct FoodSearchView: UIViewControllerRepresentable {
+    let completion: (UIImage) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        picker.modalPresentationStyle = .fullScreen
+        picker.allowsEditing = false
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    final class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let parent: FoodSearchView
+        init(parent: FoodSearchView) { self.parent = parent }
+
+        func imagePickerController(_ picker: UIImagePickerController,
+                                   didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            if let image = info[.originalImage] as? UIImage {
+                parent.completion(image)
+            }
+            parent.dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.dismiss()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add FoodSearchView to present the camera for food searching
- swap camera button to use Food Search instead of old camera search

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68b1fe2f587c8329abba408da12e1e88