### PR TITLE
Connect result view to Shortcuts and document iAPS use

### DIFF
--- a/MEAL AI/Utils/ShortcutsSender.swift
+++ b/MEAL AI/Utils/ShortcutsSender.swift
@@ -22,7 +22,7 @@ enum ShortcutsSender {
             .init(name: "x-error", value: "mealai://error")
         ]
         if sendJSON {
-            let payload = ["carbs": c, "fat": f, "protein": p]
+            let payload = ["carbs": c, "protein": p, "fat": f]
             if let data = try? JSONSerialization.data(withJSONObject: payload),
                let s = String(data: data, encoding: .utf8) {
                 items.append(.init(name: "input", value: s))

--- a/MEAL AI/Views/FoodSearch/FoodSearchResultView.swift
+++ b/MEAL AI/Views/FoodSearch/FoodSearchResultView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct FoodSearchResultView: View {
     let result: StageMealResult
     var onAddFavorite: (String) -> Void
-    var onSendToShortcuts: () -> Void
 
     @State private var favName: String = ""
     @State private var showFavSheet = false
@@ -29,7 +28,7 @@ struct FoodSearchResultView: View {
                 .buttonStyle(.bordered)
 
                 Button {
-                    onSendToShortcuts()
+                    ShortcutsSender.sendToShortcuts(stage: result)
                 } label: {
                     Label("Lähetä iAPS (Shortcut)", systemImage: "bolt")
                 }

--- a/MEAL AI/Views/FoodSearch/FoodSearchView.swift
+++ b/MEAL AI/Views/FoodSearch/FoodSearchView.swift
@@ -78,8 +78,6 @@ struct FoodSearchView: View {
         .sheet(item: $result) { r in
             FoodSearchResultView(result: r) { favName in
                 FavoritesStore.shared.add(name: favName, result: r)
-            } onSendToShortcuts: {
-                ShortcutsSender.sendToShortcuts(stage: r)
             }
         }
         .onDisappear { stopVoice() }

--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ This project is not a medical device. It has not been approved, certified, or te
 Use is at your own risk. The developers, contributors, and distributors make no warranties regarding the safety, accuracy, or functionality of this project and accept no liability for any direct, indirect, incidental, or consequential damages, injuries, illnesses, or other outcomes that may result from its use.
 
 If you have any questions or concerns regarding your health or treatment, always consult a qualified healthcare professional.
+
+## Shortcuts integration
+
+MEAL-AI can send meal macronutrient estimates to an iAPS Shortcut. When enabled in settings, the app launches a Shortcut and passes a JSON dictionary containing the rounded gram values for carbohydrates, protein and fat:
+
+```json
+{"carbs": 10, "protein": 5, "fat": 3}
+```
+
+Inside the Shortcut use **Get Dictionary from Input** to read these values. Forward the `carbs`, `protein` and `fat` entries to iAPS using whatever actions your setup requires.


### PR DESCRIPTION
## Summary
- Ensure Shortcuts payload keys are `carbs`, `protein`, and `fat`
- Trigger Shortcuts directly from the result view's Send to iAPS button
- Document how the iAPS Shortcut should parse the dictionary payload

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme "MEAL AI" -project "MEAL AI.xcodeproj"` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b2098617fc8329b2c8a87198ad6c2e